### PR TITLE
Fix scrolling background bug

### DIFF
--- a/src/components/BaseLayout.astro
+++ b/src/components/BaseLayout.astro
@@ -1,5 +1,5 @@
-<body class="font-sans antialiased min-h-screen">
-    <div class="bg-gray-100 dark:bg-gray-800 transition-colors">
+<body class="font-sans antialiased min-h-screen bg-gray-100 dark:bg-gray-800">
+    <div class="transition-colors">
         <main class="mx-auto max-w-4xl px-4 md:px-0">
             <slot />
         </main>


### PR DESCRIPTION
Before, while scrolling over the size of the window the browser showed a white background, because the background color of the body was still white.