### PR TITLE
Fix dark mode appearence provided by tailwindcss-typography 

### DIFF
--- a/src/components/Prose.astro
+++ b/src/components/Prose.astro
@@ -1,4 +1,4 @@
-<article class="prose dark:prose-dark">
+<article class="prose dark:prose-invert">
     <slot />
 </article>
 


### PR DESCRIPTION
First of all, thanks to create `astro-ink`! I'm happy to build my blog site based on this style :)

While converting my blog site into astro-ink based site, I noticed code block doesn't look pretty on dark mode.
After digging in, I found that we need to use `prose dark:prose-invert` instead of `prose dark:prose-dark` to properly support dark theme according to [official documentation of tailwindcss-typography](https://github.com/tailwindlabs/tailwindcss-typography?tab=readme-ov-file#adapting-to-dark-mode).

I have [my blog page set up with this modification](https://cj-bc.github.io/blog/posts/2024-01-26-emacs-embed-typst-code-instead-of-latex/), and looks like it's working. (code block have darker backgrond, inline-code block also have dedicated style, etc)
![image](https://github.com/one-aalam/astro-ink/assets/16875061/163c0a46-4557-46c7-a5f7-7b015e27f06f)



I also believe that this will fix #55 too.